### PR TITLE
feat(api): Add recent activities retrieval for admin dashboard and update statistics endpoint

### DIFF
--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -10,6 +10,7 @@ export default function AdminDashboard() {
     todayCheckOut: 0,
     totalSurveys: 0
   });
+  const [recentActivities, setRecentActivities] = useState([]);
 
   useEffect(() => {
     fetchStats();
@@ -27,6 +28,11 @@ export default function AdminDashboard() {
           todayCheckOut: result.data.todayCheckOut || 0,
           totalSurveys: result.data.totalSurveys || 0
         });
+        
+        // Set recent activities
+        if (result.data.recentActivities) {
+          setRecentActivities(result.data.recentActivities);
+        }
       }
     } catch (error) {
       console.error('Error fetching stats:', error);
@@ -144,15 +150,61 @@ export default function AdminDashboard() {
       <div className="bg-white rounded-xl shadow-sm border border-gray-200">
         <div className="px-8 py-6 border-b border-gray-200">
           <h3 className="text-2xl font-semibold text-gray-900">Aktivitas Terbaru</h3>
+          <p className="text-sm text-gray-500">Menampilkan aktivitas tamu dalam 24 jam terakhir</p>
         </div>
-        <div className="p-8">
-          <div className="text-center py-12">
-            <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
-              <span className="text-2xl">📋</span>
+        <div className="p-6">
+          {recentActivities.length > 0 ? (
+            <div className="overflow-hidden">
+              {recentActivities.map((activity: any, index: number) => (
+                <div 
+                  key={activity.id} 
+                  className={`flex items-center p-4 ${
+                    index < recentActivities.length - 1 ? 'border-b border-gray-100' : ''
+                  }`}
+                >
+                  <div className="w-10 h-10 mr-4 bg-blue-100 rounded-full flex items-center justify-center flex-shrink-0">
+                    <span className="text-lg">
+                      {activity.tanggapan === 'Check-in' ? '📥' : 
+                       activity.tanggapan === 'Check-out' ? '📤' : '⏳'}
+                    </span>
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex justify-between items-start">
+                      <h4 className="text-md font-medium text-gray-900">{activity.nama}</h4>
+                      <span className={`px-2 py-1 text-xs font-medium rounded-full ${
+                        activity.tanggapan === 'Check-in' ? 'bg-green-100 text-green-800' : 
+                        activity.tanggapan === 'Check-out' ? 'bg-blue-100 text-blue-800' : 
+                        'bg-yellow-100 text-yellow-800'
+                      }`}>
+                        {activity.tanggapan}
+                      </span>
+                    </div>
+                    <p className="text-sm text-gray-600 mt-1">
+                      {activity.asal_instansi && `Dari ${activity.asal_instansi}. `}
+                      {activity.keperluan && `Keperluan: ${activity.keperluan}`}
+                    </p>
+                    <p className="text-xs text-gray-500 mt-2">
+                      {new Date(activity.waktu_dibuat).toLocaleString('id-ID', {
+                        day: 'numeric',
+                        month: 'long', 
+                        year: 'numeric',
+                        hour: '2-digit',
+                        minute: '2-digit'
+                      })}
+                    </p>
+                  </div>
+                </div>
+              ))}
             </div>
-            <p className="text-gray-500 text-lg">Data aktivitas terbaru akan ditampilkan di sini</p>
-            <p className="text-gray-400 text-sm mt-2">Sistem akan mencatat semua aktivitas pengguna</p>
-          </div>
+          ) : (
+            <div className="text-center py-12">
+              <div className="w-16 h-16 bg-gray-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <span className="text-2xl">📋</span>
+              </div>
+              <p className="text-gray-500 text-lg">Belum ada aktivitas tamu dalam 24 jam terakhir</p>
+              <p className="text-gray-400 text-sm mt-2">Aktivitas terbaru akan muncul setelah tamu melakukan registrasi</p>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/app/api/statistics/route.ts
+++ b/src/app/api/statistics/route.ts
@@ -1,11 +1,12 @@
 import { NextResponse } from 'next/server';
-import { getGuestStatistics, getSurveyStatistics } from '@/backend/services/guestService';
+import { getGuestStatistics, getSurveyStatistics, getRecentActivities } from '@/backend/services/guestService';
 
 export async function GET() {
   try {
-    const [guestStats, surveyStats] = await Promise.all([
+    const [guestStats, surveyStats, recentActivities] = await Promise.all([
       getGuestStatistics(),
-      getSurveyStatistics()
+      getSurveyStatistics(),
+      getRecentActivities(5) // Get 5 most recent activities
     ]);
 
     return NextResponse.json({ 
@@ -16,6 +17,8 @@ export async function GET() {
         todayCheckIn: guestStats.todayCheckIn || 0,
         todayCheckOut: guestStats.todayCheckOut || 0,
         totalSurveys: surveyStats.total || 0,
+        // Add recent activities
+        recentActivities: recentActivities,
         // Original structure
         guests: guestStats,
         surveys: surveyStats

--- a/src/backend/services/guestService.ts
+++ b/src/backend/services/guestService.ts
@@ -254,6 +254,25 @@ export async function createAdmin(adminData: Partial<Admin>): Promise<number> {
   return result.insertId;
 }
 
+// Get Recent Activities for Dashboard (last 24 hours)
+export async function getRecentActivities(limit: number = 5): Promise<any[]> {
+  const query = `
+    SELECT 
+      id, 
+      nama, 
+      asal_instansi, 
+      keperluan, 
+      tanggapan, 
+      waktu_dibuat
+    FROM daftar_tamu 
+    WHERE waktu_dibuat >= DATE_SUB(NOW(), INTERVAL 24 HOUR)
+    ORDER BY waktu_dibuat DESC
+    LIMIT ?
+  `;
+  
+  return executeQuery<any[]>(query, [limit]);
+}
+
 // Statistics Service
 export async function getGuestStatistics(): Promise<any> {
   const totalGuestsQuery = 'SELECT COUNT(*) as total FROM daftar_tamu';


### PR DESCRIPTION
This pull request adds a new "Recent Activities" feature to the admin dashboard, allowing admins to view the latest guest activities from the last 24 hours. The changes span backend, API, and frontend code to fetch, process, and display these activities in a user-friendly format.

**Backend/API Enhancements:**

* Added a new backend service function `getRecentActivities` in `guestService.ts` to fetch the most recent guest activities from the last 24 hours, limited to a specified number (default 5).
* Updated the statistics API (`src/app/api/statistics/route.ts`) to include recent activities in its response by calling `getRecentActivities` and returning the results under the `recentActivities` key. [[1]](diffhunk://#diff-0e45bff1c5de5d145491a29d3c7e3d0279c9f664849e24a6bc8dd1009ed7b659L2-R9) [[2]](diffhunk://#diff-0e45bff1c5de5d145491a29d3c7e3d0279c9f664849e24a6bc8dd1009ed7b659R20-R21)

**Frontend Dashboard Improvements:**

* Introduced a new state variable `recentActivities` in the `AdminDashboard` component to store fetched activities and updated the data fetching logic to populate it. [[1]](diffhunk://#diff-927fe43b75aac46d9ec8908ba449fd82a7a2db3d94b1f01ffe12e453f4d42d1dR13) [[2]](diffhunk://#diff-927fe43b75aac46d9ec8908ba449fd82a7a2db3d94b1f01ffe12e453f4d42d1dR31-R35)
* Redesigned the "Aktivitas Terbaru" section in the dashboard UI to display recent guest activities, including name, institution, purpose, type of activity (check-in/check-out), and timestamp, with improved empty state messaging for when there are no activities in the last 24 hours.